### PR TITLE
Enable setting the list of supported editor formats

### DIFF
--- a/src/Blazored.TextEditor/BlazoredTextEditor.razor
+++ b/src/Blazored.TextEditor/BlazoredTextEditor.razor
@@ -27,6 +27,33 @@
         = "snow";
 
     [Parameter]
+    public string[] Formats { get; set; }
+        = new[]
+        {
+            "background",
+            "bold",
+            "color",
+            "font",
+            "code",
+            "italic",
+            "link",
+            "size",
+            "strike",
+            "script",
+            "underline",
+            "blockquote",
+            "header",
+            "indent",
+            "list",
+            "align",
+            "direction",
+            "code-block",
+            "formula",
+            "image",
+            "video"
+        };
+
+    [Parameter]
     public string DebugLevel { get; set; }
         = "info";
 
@@ -45,6 +72,7 @@
                 ReadOnly,
                 Placeholder,
                 Theme,
+                Formats,
                 DebugLevel);
         }
     }

--- a/src/Blazored.TextEditor/BlazoredTextEditor.razor
+++ b/src/Blazored.TextEditor/BlazoredTextEditor.razor
@@ -28,30 +28,7 @@
 
     [Parameter]
     public string[] Formats { get; set; }
-        = new[]
-        {
-            "background",
-            "bold",
-            "color",
-            "font",
-            "code",
-            "italic",
-            "link",
-            "size",
-            "strike",
-            "script",
-            "underline",
-            "blockquote",
-            "header",
-            "indent",
-            "list",
-            "align",
-            "direction",
-            "code-block",
-            "formula",
-            "image",
-            "video"
-        };
+        = null;
 
     [Parameter]
     public string DebugLevel { get; set; }

--- a/src/Blazored.TextEditor/Interop.cs
+++ b/src/Blazored.TextEditor/Interop.cs
@@ -13,12 +13,13 @@ namespace Blazored.TextEditor
             bool readOnly,
             string placeholder,
             string theme,
+            string[] formats,
             string debugLevel)
         {
             return jsRuntime.InvokeAsync<object>(
                 "QuillFunctions.createQuill", 
                 quillElement, toolbar, readOnly, 
-                placeholder, theme, debugLevel);
+                placeholder, theme, formats, debugLevel);
         }
 
         internal static ValueTask<string> GetText(

--- a/src/Blazored.TextEditor/wwwroot/Blazored-BlazorQuill.js
+++ b/src/Blazored.TextEditor/wwwroot/Blazored-BlazorQuill.js
@@ -14,9 +14,12 @@
                 },
                 placeholder: placeholder,
                 readOnly: readOnly,
-                theme: theme,
-                formats: formats
+                theme: theme
             };
+
+            if (formats) {
+                options.formats = formats;
+            }
 
             new Quill(quillElement, options);
         },

--- a/src/Blazored.TextEditor/wwwroot/Blazored-BlazorQuill.js
+++ b/src/Blazored.TextEditor/wwwroot/Blazored-BlazorQuill.js
@@ -2,7 +2,7 @@
     window.QuillFunctions = {        
         createQuill: function (
             quillElement, toolBar, readOnly,
-            placeholder, theme, debugLevel) {  
+            placeholder, theme, formats, debugLevel) {  
 
             Quill.register('modules/blotFormatter', QuillBlotFormatter.default);
 
@@ -14,7 +14,8 @@
                 },
                 placeholder: placeholder,
                 readOnly: readOnly,
-                theme: theme
+                theme: theme,
+                formats: formats
             };
 
             new Quill(quillElement, options);


### PR DESCRIPTION
QuillJS supports setting the text format options in the editor area. This change wires that feature up into the Blazor Interop layer. This is useful when I only want to show a subset of the QuillJS format options on my editor.