### PR TITLE
Enable css styling

### DIFF
--- a/src/Blazored.TextEditor/Blazored.TextEditor.csproj
+++ b/src/Blazored.TextEditor/Blazored.TextEditor.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Blazored.TextEditor</RootNamespace>
 
     <PackageId>Blazored.TextEditor</PackageId>
-    <Version>1.0.8</Version>
+    <Version>1.1.0</Version>
     <Authors>Michael Washington</Authors>
     <Description>Rich text editor for Blazor applications - Uses Quill JS</Description>
     <Copyright>Copyright 2022 (c) Michael Washington. All rights reserved.</Copyright>
@@ -16,7 +16,8 @@
     <RepositoryUrl>https://github.com/Blazored/TextEditor</RepositoryUrl>
     <PackageTags>Blazor Rich Text Editor Quill QuillJS Blazored Razor Components</PackageTags>
     <Company />
-    <PackageReleaseNotes>Adds Id to Div</PackageReleaseNotes>
+    <PackageReleaseNotes>Add support for css class and style attributes</PackageReleaseNotes>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Blazored.TextEditor/BlazoredTextEditor.razor
+++ b/src/Blazored.TextEditor/BlazoredTextEditor.razor
@@ -1,13 +1,23 @@
 ﻿@inject IJSRuntime JSRuntime
 
-<div id="QuillToolBar" @ref="@ToolBar">
-    @ToolbarContent
-</div>
-<div id="QuillEditor" @ref="@QuillElement">
+@if (!BottomToolbar)
+{
+    <div class="@ToolbarCSSClass" id="QuillToolBar" @ref="@ToolBar" style="@ToolbarCssStyle">
+        @ToolbarContent
+    </div>
+}
+<div class="@EditorCssClass" id="QuillEditor" @ref="@QuillElement" style="@EditorCssStyle">
     @EditorContent
 </div>
+@if (BottomToolbar)
+{
+    <div class="@ToolbarCSSClass" id="QuillBottomToolbar" @ref="@ToolBar" style="@ToolbarCssStyle">
+        @ToolbarContent
+    </div>
+}
 
 @code {
+
     [Parameter]
     public RenderFragment EditorContent { get; set; }
 
@@ -33,6 +43,37 @@
     [Parameter]
     public string DebugLevel { get; set; }
         = "info";
+
+    /// <summary>
+    /// Support for normal css classes
+    /// </summary>
+    [Parameter]
+    public string EditorCssClass { get; set; }
+        = string.Empty;
+
+    /// <summary>
+    /// Support for normal css styles
+    /// </summary>
+    [Parameter]
+    public string EditorCssStyle { get; set; }
+        = string.Empty;
+
+    /// <summary>
+    /// Support for normal css classes
+    /// </summary>
+    [Parameter]
+    public string ToolbarCSSClass { get; set; }
+        = string.Empty;
+
+    /// <summary>
+    /// Support for normal css styles
+    /// </summary>
+    [Parameter]
+    public string ToolbarCssStyle { get; set; }
+        = string.Empty;
+
+    [Parameter]
+    public bool BottomToolbar { get; set; }
 
     private ElementReference QuillElement;
     private ElementReference ToolBar;
@@ -106,4 +147,5 @@
             await Interop.EnableQuillEditor(
                 JSRuntime, QuillElement, mode);
     }
+
 }


### PR DESCRIPTION
The new property names can be modified. The essential aspect is the flexibility to customize both the Toolbar and the Editor. This customization capability proves helpful in resolving an issue encountered while using the Editor on Android. Specifically, when text is selected within the Editor, the Android popup text selector conceals the Toolbar buttons, rendering them unusable. By adding padding to the top of the editor, this problem can be effectively resolved. Additionally, enabling styling on the Editor becomes an added advantage.