### PR TITLE
Allow setting custom ids for the toolbar and editor

### DIFF
--- a/samples/BlazorClientSide/Pages/Home.razor
+++ b/samples/BlazorClientSide/Pages/Home.razor
@@ -1,7 +1,9 @@
 ﻿@page "/"
 @using Blazored.TextEditor
 
-<BlazoredTextEditor @ref="@QuillHtml">
+<BlazoredTextEditor @ref="@QuillHtml"
+                    EditorId="QuillEditor1"
+                    ToolbarId="QuillToolBar1">
     <ToolbarContent>
         <select class="ql-header">
             <option selected=""></option>
@@ -53,6 +55,8 @@
 </div>
 <br />
 <BlazoredTextEditor @ref="@QuillNative"
+                    EditorId="QuillEditor2"
+                    ToolbarId="QuillToolBar2"
                     Placeholder="Enter non HTML format like centering...">
     <ToolbarContent>
         <span class="ql-formats">
@@ -120,6 +124,8 @@
 <br />
 <br />
 <BlazoredTextEditor @ref="@QuillReadOnly"
+                    EditorId="QuillEditor3"
+                    ToolbarId="QuillToolBar3"
                     ReadOnly="true"
                     Theme="bubble"
                     DebugLevel="log">
@@ -167,7 +173,8 @@
 <!-- ----- ----- ----- ----- ----- -->
 <h2>Syntax Highlighter</h2>
 <p>Off</p>
-<BlazoredTextEditor>
+<BlazoredTextEditor EditorId="QuillEditor4"
+                    ToolbarId="QuillToolBar4">
     <ToolbarContent>
         <span class="ql-formats">
             <button class="ql-code-block"></button>
@@ -181,7 +188,10 @@ console.<span class="hljs-built_in">log</span>("I love " <span class="hljs-opera
 </BlazoredTextEditor>
 
 <p>On</p>
-<BlazoredTextEditor @ref="@QuillCode" Syntax="true">
+<BlazoredTextEditor @ref="@QuillCode"
+                    EditorId="QuillEditor5"
+                    ToolbarId="QuillToolBar5"
+                    Syntax="true">
     <ToolbarContent>
         <span class="ql-formats">
             <button class="ql-code-block"></button>

--- a/samples/BlazorServerSide/Components/Pages/Home.razor
+++ b/samples/BlazorServerSide/Components/Pages/Home.razor
@@ -1,7 +1,9 @@
 ﻿@page "/"
 @using Blazored.TextEditor
 
-<BlazoredTextEditor @ref="@QuillHtml">
+<BlazoredTextEditor @ref="@QuillHtml"
+                    EditorId="QuillEditor1"
+                    ToolbarId="QuillToolBar1">
     <ToolbarContent>
         <select class="ql-header">
             <option selected=""></option>
@@ -27,7 +29,6 @@
         </span>
         <span class="ql-formats">
             <button class="ql-link"></button>
-            <button class="ql-image"></button>
         </span>
     </ToolbarContent>
     <EditorContent>
@@ -54,6 +55,8 @@
 </div>
 <br />
 <BlazoredTextEditor @ref="@QuillNative"
+                    EditorId="QuillEditor2"
+                    ToolbarId="QuillToolBar2"
                     Placeholder="Enter non HTML format like centering...">
     <ToolbarContent>
         <span class="ql-formats">
@@ -121,6 +124,8 @@
 <br />
 <br />
 <BlazoredTextEditor @ref="@QuillReadOnly"
+                    EditorId="QuillEditor3"
+                    ToolbarId="QuillToolBar3"
                     ReadOnly="true"
                     Theme="bubble"
                     DebugLevel="log">
@@ -168,26 +173,33 @@
 <!-- ----- ----- ----- ----- ----- -->
 <h2>Syntax Highlighter</h2>
 <p>Off</p>
-<BlazoredTextEditor>
+<BlazoredTextEditor EditorId="QuillEditor4"
+                    ToolbarId="QuillToolBar4">
     <ToolbarContent>
         <span class="ql-formats">
             <button class="ql-code-block"></button>
         </span>
     </ToolbarContent>
     <EditorContent>
-<pre class="ql-syntax" spellcheck="false">const <span class="hljs-keyword">language</span> <span class="hljs-operator">=</span> "JavaScript";
+<pre class="ql-syntax" spellcheck="false">
+const <span class="hljs-keyword">language</span> <span class="hljs-operator">=</span> "JavaScript";
 console.<span class="hljs-built_in">log</span>("I love " <span class="hljs-operator">+</span> <span class="hljs-keyword">language</span> <span class="hljs-operator">+</span> "!");</pre>
     </EditorContent>
 </BlazoredTextEditor>
+
 <p>On</p>
-<BlazoredTextEditor @ref="@QuillCode" Syntax="true">
+<BlazoredTextEditor @ref="@QuillCode"
+                    EditorId="QuillEditor5"
+                    ToolbarId="QuillToolBar5"
+                    Syntax="true">
     <ToolbarContent>
         <span class="ql-formats">
             <button class="ql-code-block"></button>
         </span>
     </ToolbarContent>
     <EditorContent>
-<pre class="ql-syntax" spellcheck="false">const <span class="hljs-keyword">language</span> <span class="hljs-operator">=</span> "JavaScript";
+<pre class="ql-syntax" spellcheck="false">
+const <span class="hljs-keyword">language</span> <span class="hljs-operator">=</span> "JavaScript";
 console.<span class="hljs-built_in">log</span>("I love " <span class="hljs-operator">+</span> <span class="hljs-keyword">language</span> <span class="hljs-operator">+</span> "!");</pre>
     </EditorContent>
 </BlazoredTextEditor>
@@ -203,7 +215,7 @@ console.<span class="hljs-built_in">log</span>("I love " <span class="hljs-opera
     @QuillHTMLCodeContent
 </div>
 <br />
-<!-- ----- ----- ----- ----- -->
+
 @code {
     BlazoredTextEditor QuillHtml;
     BlazoredTextEditor QuillNative;
@@ -226,7 +238,7 @@ console.<span class="hljs-built_in">log</span>("I love " <span class="hljs-opera
         {
             QuillHTMLContent = await this.QuillHtml.GetHTML(cts.Token);
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException e)
         {
             QuillHTMLContent = "<p>ERROR: Timeout</p>";
         }
@@ -249,17 +261,14 @@ console.<span class="hljs-built_in">log</span>("I love " <span class="hljs-opera
     {
         await this.QuillNative.LoadContent(QuillContent);
     }
-
     public async Task InsertImage()
     {
         await this.QuillNative.InsertImage("images/BlazorHelpWebsite.gif");
     }
-
     public async Task InsertText()
     {
         await this.QuillNative.InsertText("Some Text");
     }
-
     async Task ToggleQuillEditor()
     {
         mode = (mode) ? false : true;

--- a/src/Blazored.TextEditor/BlazoredTextEditor.razor
+++ b/src/Blazored.TextEditor/BlazoredTextEditor.razor
@@ -2,21 +2,37 @@
 
 @if (!BottomToolbar)
 {
-    <div class="@ToolbarCSSClass" id="QuillToolBar" @ref="@ToolBar" style="@ToolbarCssStyle">
+    <div class="@ToolbarCSSClass" id="@GetToolbarId()" @ref="@ToolBar" style="@ToolbarCssStyle">
         @ToolbarContent
     </div>
 }
-<div class="@EditorCssClass" id="QuillEditor" @ref="@QuillElement" style="@EditorCssStyle">
+<div class="@EditorCssClass" id="@EditorId" @ref="@QuillElement" style="@EditorCssStyle">
     @EditorContent
 </div>
 @if (BottomToolbar)
 {
-    <div class="@ToolbarCSSClass" id="QuillBottomToolbar" @ref="@ToolBar" style="@ToolbarCssStyle">
+    <div class="@ToolbarCSSClass" id="@GetToolbarId()" @ref="@ToolBar" style="@ToolbarCssStyle">
         @ToolbarContent
     </div>
 }
 
 @code {
+    /// <summary>
+    /// Set a custom id for the editor. Recommended if you have multiple BlazoredTextEditors on the same page.
+    /// </summary>
+    [Parameter]
+    public string EditorId { get; set; } = "QuillEditor";
+
+    /// <summary>
+    /// Set a custom id for the toolbar. Recommended if you have multiple BlazoredTextEditors on the same page.
+    /// </summary>
+    [Parameter]
+    public string ToolbarId { get; set; } = null;
+
+    private string GetToolbarId()
+    {
+        return ToolbarId ?? (!BottomToolbar ? "QuillToolBar" : "QuillBottomToolbar");
+    }
 
     [Parameter]
     public RenderFragment EditorContent { get; set; }


### PR DESCRIPTION
If you have multiple BlazoredTextEditors on the same page then you'll end up with elements with the same id.
Ids are supposed to be unique in html so this change will improve html semantics of the page. 

I didn't want to introduce any breaking changes so I didn't remove the id (this could be a breaking change if someone is using custom javascript) nor make it required (this would be a breaking change).

